### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Overview
This PR adds the **GitHub Skills** activity that was announced by the principal and requested in issue #6.

## Changes
- Added "GitHub Skills" to the activities dictionary in `src/app.py`
- Activity is configured for 25 participants
- Schedule: Mondays and Wednesdays, 3:30 PM - 5:00 PM
- Description references the GitHub Certifications program to help students with college applications

## Why This Is Important
- **Time-sensitive**: Registration closes by the end of this week
- **Student impact**: Many students (including Hewbie C., 11th grade) are eager to join
- **College applications**: This is the first part of the GitHub Certifications program

## Testing
The activity will now appear in the activities list and students can sign up using the existing signup endpoint.

Closes #6